### PR TITLE
test: fix parameter name in create paypal account

### DIFF
--- a/PromisePayDotNet.Tests/DynamicPayPalAccountTest.cs
+++ b/PromisePayDotNet.Tests/DynamicPayPalAccountTest.cs
@@ -34,7 +34,7 @@ namespace PromisePayDotNet.Tests
                 {"active" , true},
                 {"paypal" , new Dictionary<string, object>
                 {
-                    {"email", "aaa@bbb.com"}
+                    {"paypal_email", "aaa@bbb.com"}
                 }}
             };
             var resp = repo.CreatePayPalAccount(account);


### PR DESCRIPTION
This commit updates the paypal account test to reflect the latest
parameter name as implented in our API.